### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ No questions asked.
 
 ## 📓 Table of Contents
 
-- [Installation](#installation)
+- [Installation](#%EF%B8%8Finstallation)
   
 - [Usage](#usage)
   
-- [Screenshot](#screenshot)
+- [Screenshot](#%EF%B8%8Fscreenshot)
   
 - [Video](#video)
   
-- [License](#license)
+- [License](#%EF%B8%8Flicense)
   
 - [Contributing](#contributing)
   
-- [Tests](#tests)
+- [Tests](#%EF%B8%8Ftests)
   
 - [Questions](#questions)
     


### PR DESCRIPTION
- so the emojis were causing github to generate heading anchors with this sequence %EF%B8%8F in place of the emoji.
- github would normally just cull any emojis from the generated heading anchor but for some reason it wasn't doing it for some of them.
- adding the sequence to the table of contents links so that they match the anchors fixed the issue